### PR TITLE
Update Dockerfile from Ubuntu to Alpine for its base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,10 @@
-FROM ubuntu:24.04
+# Use Alpine as the base image
+FROM alpine:latest
 
-RUN apt-get update \
-    && apt-get install ca-certificates -y \
-    && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install -y cron curl \
-    # Remove package lists for smaller image sizes
-    && rm -rf /var/lib/apt/lists/* \
-    && which cron \
-    && rm -rf /etc/cron.*/*
+# Install a package (e.g., curl)
+RUN apk add --no-cache ca-certificates curl
 
+# Copy other files
 COPY crontab /hello-cron
 COPY entrypoint.sh /entrypoint.sh
 
@@ -16,7 +13,6 @@ RUN chmod +x entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
 
-# https://manpages.ubuntu.com/manpages/trusty/man8/cron.8.html
 # -f | Stay in foreground mode, don't daemonize.
-# -L loglevel | Tell  cron  what to log about jobs (errors are logged regardless of this value) as the sum of the following values:
-CMD ["cron","-f", "-L", "2"]
+# -l loglevel | Tell  cron  what to log about jobs (errors are logged regardless of this value) as the sum of the following values:
+CMD ["crond","-f", "-l", "2"]


### PR DESCRIPTION
Update Dockerfile from ubuntu:24.04 to alpine:latest for its base image, decreasing base image from ~104MB to ~13MB